### PR TITLE
Remove compile warnings 

### DIFF
--- a/lib/evaluator.ex
+++ b/lib/evaluator.ex
@@ -5,7 +5,7 @@ defmodule Veritaserum.Evaluator do
 
   ["word", "emoticon", "negator", "booster"]
   |> Enum.each(fn facet ->
-    map =
+    facet_mapping =
       "#{__DIR__}/../config/facets/#{facet}.json"
       |> File.read!()
       |> Jason.decode!()
@@ -16,7 +16,7 @@ defmodule Veritaserum.Evaluator do
         Veritaserum.Evaluator.#{facet}_list()
     """
     def unquote(:"#{facet}_list")(),
-      do: unquote(Map.keys(map))
+      do: unquote(Map.keys(facet_mapping))
 
     @doc """
     Evaluates if a word/emoji is a **#{facet}** and returns value.
@@ -28,7 +28,7 @@ defmodule Veritaserum.Evaluator do
     """
     def unquote(:"evaluate_#{facet}")(word_or_emoji)
 
-    Enum.each(map, fn {word, value} ->
+    Enum.each(facet_mapping, fn {word, value} ->
       def unquote(:"evaluate_#{facet}")(unquote(word)), do: unquote(value)
     end)
 

--- a/lib/evaluator.ex
+++ b/lib/evaluator.ex
@@ -1,25 +1,34 @@
 defmodule Veritaserum.Evaluator do
   @moduledoc """
-  Evaluats words, boosters, negators and emoticons.
+  Evaluates words, boosters, negators and emoticons.
   """
 
   ["word", "emoticon", "negator", "booster"]
   |> Enum.each(fn facet ->
-    File.read!("#{__DIR__}/../config/facets/#{facet}.json")
-    |> Jason.decode!()
-    |> (fn list ->
-          def unquote(:"#{facet}_list")(),
-            do: unquote(list |> Enum.map(fn {key, _} -> key end) |> List.flatten())
+    map =
+      "#{__DIR__}/../config/facets/#{facet}.json"
+      |> File.read!()
+      |> Jason.decode!()
 
-          list
-        end).()
-    |> Enum.each(fn {word, value} ->
-      @doc """
-      Evaluates if a word/emoji is a **#{facet}** and returns value.
+    @doc """
+    Returns a list of words/emojis which affect **#{facet}** sentiment.
 
-          iex> Veritaserum.Evaluator.evaluate_#{facet}("#{word}")
-          #{value}
-      """
+        Veritaserum.Evaluator.#{facet}_list()
+    """
+    def unquote(:"#{facet}_list")(),
+      do: unquote(Map.keys(map))
+
+    @doc """
+    Evaluates if a word/emoji is a **#{facet}** and returns value.
+    Otherwise returns `nil`.
+
+        Veritaserum.Evaluator.evaluate_#{facet}("very")
+        Veritaserum.Evaluator.evaluate_#{facet}("can't")
+        Veritaserum.Evaluator.evaluate_#{facet}("afraid")
+    """
+    def unquote(:"evaluate_#{facet}")(word_or_emoji)
+
+    Enum.each(map, fn {word, value} ->
       def unquote(:"evaluate_#{facet}")(unquote(word)), do: unquote(value)
     end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Veritaserum.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :jason]]
   end
 
   defp package do
@@ -53,6 +53,7 @@ defmodule Veritaserum.Mixfile do
 
   defp deps do
     [
+      {:jason, "~> 1.0"},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},


### PR DESCRIPTION
1. Removes the following warning which is generated many times during compilation
```
warning: redefining @doc attribute previously set at line 17.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

    @doc """
    new docs
    """
    def evaluate_emoticon(...)

  lib/evaluator.ex:17: Veritaserum.Evaluator.evaluate_emoticon/1
```
2. Removes `jason` warning:
```
warning: Jason.decode!/1 defined in application :jason is used by the current application but the current application does not depend on :jason. To fix this, you must do one of:

  1. If :jason is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :jason is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :jason, you may optionally skip this warning by adding [xref: [exclude: [Jason]]] to your "def project" in mix.exs

  lib/evaluator.ex:11: Veritaserum.Evaluator
```
